### PR TITLE
OrionWS - ScorpioXL - XML - Multicom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "pg": "^8.13.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "simple-xml-to-json": "^1.2.3",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -11496,6 +11497,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz",
+      "integrity": "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
       }
     },
     "node_modules/sisteransi": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "simple-xml-to-json": "^1.2.3",
     "typeorm": "^0.3.20"
   },
   "devDependencies": {

--- a/src/Scorpio/xml/controllers/multicom/multicom.controller.ts
+++ b/src/Scorpio/xml/controllers/multicom/multicom.controller.ts
@@ -75,6 +75,6 @@ export class MulticomController {
     @GetUser('id') idUser: number,
     @Param('id') id: number 
   ) {
-    return this.Service.XML_MultComprobante_Verificar(idUser, id);
+    return this.Service.XML_MultComprobante_Verificar_XML_JSON(idUser, id);
   }
 }

--- a/src/Scorpio/xml/services/multicom/multicom.service.ts
+++ b/src/Scorpio/xml/services/multicom/multicom.service.ts
@@ -158,7 +158,6 @@ export class MulticomService {
       
       //peticion con axios
       const res = await this.http.httpPost(data[0].sp_build_xml_verifica.XML[6].valor, Body );
-      console.log(res)
 
       if(res.codigo !== 0){
         return {
@@ -172,24 +171,33 @@ export class MulticomService {
       //peticion con axios
       const params = await this.http.buildQueryParams( res.respuesta[0] );
 
-      //log  response
-      console.log(res.respuesta[0])
 
       // convertir a JSON 
       const url = await this.http.buildUrl( res.respuesta[0] );
-      console.log(url)
 
-      const response = await this.http.httpGet( url, params );
-      console.log(response)
+      const xml = await this.http.httpGet( url, params );
+
+      // const response = await this.http.removerFirma( xml );
+
+      const cleanedResponse = await this.removeBeforeXml(xml);
       
-      //devolver el JSON 
+      // console.log(cleanedResponse.slice(4));
 
+
+      const xmlFinal = await this.removeAfterClosingTag(cleanedResponse.slice(4));
+
+      // console.log(xmlFinal);
+
+
+      //devolver el JSON
+      const myJson = convertXML(xmlFinal)
+      console.log(JSON.stringify(myJson))
       // Retornamos la respuesta formateada si la solicitud fue exitosa
       return {
         Success: true,
         Titulo: 'OrionWS: Scorpio XL - Modulo XML - Multicomprobantes Verificar',
         Mensaje: 'Operación Realizada con exito.',
-        Response: response,
+        Response: myJson,
       };
     } catch (error) {
       console.error('Error en la solicitud HTTP:', error.message);
@@ -205,6 +213,16 @@ export class MulticomService {
     }
   }
 
+  public removeBeforeXml(data: string): string {
+    const regex = /.*(?=\.xml)/; // Coincide con todo antes de ".xml" (sin incluirlo)
+    return data.replace(regex, ''); // Reemplaza todo lo anterior por una cadena vacía
+  }
+
+  public removeAfterClosingTag(data: string): string {
+    // Usamos una expresión regular para encontrar `</cfdi:Comprobante>` y todo lo que sigue
+    const regex = /(<\/cfdi:Comprobante>).*$/;
+    return data.replace(regex, '$1'); // Reemplazamos todo después de `</cfdi:Comprobante>`
+  }
 
 
 

--- a/src/shared/client/clienthttp.ts
+++ b/src/shared/client/clienthttp.ts
@@ -81,6 +81,24 @@ export class clientHttp {
     return urlObject.toString();
   }
 
+  //Helper
+  public removerFirma(input: string): string {
+    // Decodifica el contenido binario utilizando Buffer
+    const decoded = Buffer.from(input, 'base64').toString('utf-8');
+
+    // Expresión regular para encontrar el XML dentro de la cadena
+    const xmlRegex = /<\?xml[\s\S]*<cfdi:Comprobante[\s\S]*<\/cfdi:Comprobante>/;
+
+    // Extrae solo el XML usando la expresión regular
+    const xmlMatch = decoded.match(xmlRegex);
+
+    if (xmlMatch) {
+      return xmlMatch[0]; // Devuelve solo el XML
+    }
+
+    throw new Error('No XML content found');
+  }
+
   
 
 }

--- a/src/shared/client/clienthttp.ts
+++ b/src/shared/client/clienthttp.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
-import { catchError, firstValueFrom } from 'rxjs';
+import { catchError, firstValueFrom, lastValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 
 @Injectable()
@@ -29,20 +29,58 @@ export class clientHttp {
     }
   }
 
-  public async httpGet(url: string) {
+  //Armamos los parametros
+  public buildQueryParams(url: string): Record<string, string> {
+    const parsedUrl = new URL(url);
+    const queryParams: Record<string, string> = {};
+
+    parsedUrl.searchParams.forEach((value, key) => {
+      queryParams[key] = value;
+    });
+
+    return queryParams;
+  }
+
+  public buildUrl(url: string): string {
+    const parsedUrl = new URL(url);
+
+    // Elimina los parámetros query
+    parsedUrl.search = '';
+
+    return parsedUrl.toString();
+  }
+
+  public async httpGet(url: string, queryParams?: Record<string, string>): Promise<any> {
     try {
-      const response = await this.httpService
-      .get<any>( url )
-      .pipe(
-        catchError((error: AxiosError) => {
-          console.error('Error:', error.response?.data || error.message);
-          throw new Error('algo paso en el servicio: http ');
-        }),
+      const fullUrl = this.buildUrlWithParams(url, queryParams);
+
+      const response = await lastValueFrom(
+        this.httpService.get<any>(fullUrl).pipe(
+          catchError((error: AxiosError) => {
+            console.error('Error:', error.response?.data || error.message);
+            throw new Error('Algo pasó en el servicio HTTP');
+          }),
+        )
       );
-      return response;
+
+      return response.data;
     } catch (error) {
-      console.error('Error http POST request:', error);
+      console.error('Error en la solicitud HTTP GET:', error);
       throw error;
     }
   }
+
+  private buildUrlWithParams(url: string, queryParams?: Record<string, string>): string {
+    if (!queryParams) return url;
+
+    const urlObject = new URL(url);
+    Object.entries(queryParams).forEach(([key, value]) => {
+      urlObject.searchParams.append(key, value);
+    });
+
+    return urlObject.toString();
+  }
+
+  
+
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,6 +6346,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-xml-to-json@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.3.tgz"
+  integrity sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"


### PR DESCRIPTION
Se instaló la librería simple-xml-to-json para convertir de formato XML a formato JSON. Se agregaron funciones para extraer los query params de la URL (buildQueryParams) y  para generar URL sin parámetros (buildUrl). También se implementaron dos funciones adicionales (removeBeforeXml y removeAfterClosingTag) para limpiar contenido al inicio y al final del XML para poder convertirlo a JSON.